### PR TITLE
Gracefully handle cases of empty/unparsed domain emails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whois-format"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 authors = [
     { name="Darren Spruell", email="phatbuckett@gmail.com" },
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 requires =
     tox
-env_list = format, lint, type, py{38,39,310,311}
+env_list = format, lint, type, py{38,310,311}
 
 [testenv]
 description = run unit tests

--- a/whois_format.py
+++ b/whois_format.py
@@ -110,8 +110,13 @@ def cli():
         data.append(", ".join(ns_list or ["-"]))
         data.append(w.get("name") or w.get("org", DEFAULT_STR))
         emails = w.get("emails", [DEFAULT_STR])
+        logging.debug("emails: %s", emails)
+        if emails is None:
+            emails = [DEFAULT_STR]
+            logging.debug("emails: %s", emails)
         if not isinstance(emails, list):
             emails = [emails]
+            logging.debug("emails: %s", emails)
         data.append(", ".join(emails))
 
         resp_data.append(data)


### PR DESCRIPTION
- Handle cases of empty domain email contacts.
- Add additional debug statements for this field.

Resolve #3