### PR TITLE
Gracefully handle WHOIS errors such as nonexistent domains

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whois-format"
-version = "0.1.0-alpha.9"
+version = "0.1.0-alpha.10"
 authors = [
     { name="Darren Spruell", email="phatbuckett@gmail.com" },
 ]


### PR DESCRIPTION
Add error handling for WHOIS errors like nonexistent domains.
- Maintain list of encountered errors
- Output successful domain lookups like normal
- Afterward, output a warning message with encountered domains and errors logged to stderr