### PR TITLE
Refactor main logic into a basic library function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "whois-format"
-version = "0.1.0-alpha.11"
+version = "0.1.0-alpha.12"
 authors = [
     { name="Darren Spruell", email="phatbuckett@gmail.com" },
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ skip_install = true
 deps =
     black
 commands =
-    black -l 79 {posargs:.}
+    black -l 79 {posargs:whois_format.py}
 
 [testenv:lint]
 description = run linters
@@ -26,7 +26,7 @@ deps =
     flake8
     flake8-docstrings
 commands =
-    flake8 --docstring-convention pep257 {posargs:.}
+    flake8 --docstring-convention pep257 {posargs:whois_format.py}
 
 [testenv:type]
 description = run type checks

--- a/whois_format.py
+++ b/whois_format.py
@@ -29,6 +29,94 @@ def get_ns_domains(nameservers: list) -> list:
     return list(x)
 
 
+def get_domain_whois(domains: list, pause: int = NUM_SLEEP_SECONDS) -> dict:
+    """Return domain attributes for each input domain.
+
+    Perform a WHOIS lookup for each input domain. Sleep for `pause` seconds
+    between lookups to avoid rate limiting by servers queried for multiple
+    domains.
+
+    Due to the possibility that some domains may succeed and others fail,
+    return a dictionary object with the following keys:
+
+    - `responses`: a list of lists of domain information for each domain
+      successfully queried in WHOIS.
+    - `warnings`: a list of errors for each domain that failed to return a
+      response from WHOIS.
+
+    Arguments:
+    domains -- list of domains for which to query WHOIS
+
+    Keyword arguments:
+    pause -- number of seconds to pause between WHOIS queries (default:
+    constant)
+    """
+    val = 0
+    resp_data: dict[str, list] = {
+        "responses": [],
+        "warnings": [],
+    }
+    for domain in domains:
+        val += 1
+        data = []
+        domain = domain.strip().lower()
+        logging.debug("about to query for domain: %s", domain)
+        try:
+            w = whois(domain)
+        except PywhoisError as e:
+            # Take the first line of output as the error to pass back to the
+            # caller.
+            err = str(e).partition("\n")[0]
+            resp_data["warnings"].append([domain, err])
+            logging.debug("encountered error for domain %s: %s", domain, err)
+            continue
+        logging.debug("completed query for domain: %s; result: %s", domain, w)
+        if w.domain_name is None:
+            logging.error(
+                "%s: received null response to lookup "
+                "(possible nonexistent domain or WHOIS library issue)",
+                domain,
+            )
+            continue
+
+        # Build return data as a list of fields from attributes of the
+        # response.
+        # Field ordering matters - keep to this format:
+        # domain, creation_date, registrar, nameservers, registrant name or
+        # organization, registrant email(s)
+        data.append(w.domain.upper())
+        creation = w.get("creation_date")
+        if isinstance(creation, list):
+            dt = creation[0]
+        else:
+            dt = creation
+        if isinstance(dt, datetime.datetime):
+            data.append(dt.strftime("%Y-%m-%d"))
+        else:
+            data.append(DEFAULT_STR)
+        data.append(w.get("registrar", DEFAULT_STR))
+        ns_list = get_ns_domains(w.get("name_servers", []))
+        data.append(", ".join(ns_list or ["-"]))
+        data.append(w.get("name") or w.get("org", DEFAULT_STR))
+        # Multiple email addresses may be extracted from the WHOIS record, so
+        # attempt to return all of them to maximize context.
+        emails = w.get("emails", [DEFAULT_STR])
+        logging.debug("emails: %s", emails)
+        if emails is None:
+            emails = [DEFAULT_STR]
+            logging.debug("emails: %s", emails)
+        if not isinstance(emails, list):
+            emails = [emails]
+            logging.debug("emails: %s", emails)
+        data.append(", ".join(emails))
+
+        resp_data["responses"].append(data)
+        if val < len(domains):
+            sleep(pause)
+
+    return resp_data
+
+
 def cli():
     """CLI entry point."""
     description = "Whois client wrapper producing a terse, single-line format."
@@ -68,69 +156,15 @@ def cli():
     if args.debug:
         logging.getLogger().setLevel(logging.DEBUG)
 
-    resp_data = []
-
     if args.in_file:
         lookup_domains = args.in_file.readlines()
     else:
         lookup_domains = args.domain
 
-    val = 0
-    msgs_warning = []
-    for domain in lookup_domains:
-        val += 1
-        data = []
-        domain = domain.strip().lower()
-        logging.debug("about to query for domain: %s", domain)
-        try:
-            w = whois(domain)
-        except PywhoisError as e:
-            err = str(e).partition("\n")[0]
-            msgs_warning.append([domain, err])
-            logging.debug("encountered error for domain %s: %s", domain, err)
-            continue
-        logging.debug("completed query for domain: %s; result: %s", domain, w)
-        if w.domain_name is None:
-            logging.error(
-                "%s: received null response to lookup "
-                "(possible WHOIS library issue)",
-                domain,
-            )
-            continue
+    resp_data = get_domain_whois(lookup_domains, args.sleep)
 
-        # Field ordering matters - keep to this format:
-        # domain, creation_date, registrar, nameservers, registrant name or
-        # organization, registrant email(s)
-
-        data.append(w.domain.upper())
-        creation = w.get("creation_date")
-        if isinstance(creation, list):
-            dt = creation[0]
-        else:
-            dt = creation
-        if isinstance(dt, datetime.datetime):
-            data.append(dt.strftime("%Y-%m-%d"))
-        else:
-            data.append(DEFAULT_STR)
-        data.append(w.get("registrar", DEFAULT_STR))
-        ns_list = get_ns_domains(w.get("name_servers", []))
-        data.append(", ".join(ns_list or ["-"]))
-        data.append(w.get("name") or w.get("org", DEFAULT_STR))
-        emails = w.get("emails", [DEFAULT_STR])
-        logging.debug("emails: %s", emails)
-        if emails is None:
-            emails = [DEFAULT_STR]
-            logging.debug("emails: %s", emails)
-        if not isinstance(emails, list):
-            emails = [emails]
-            logging.debug("emails: %s", emails)
-        data.append(", ".join(emails))
-
-        resp_data.append(data)
-        if val < len(lookup_domains):
-            sleep(args.sleep)
-
-    print(tabulate(resp_data, tablefmt="plain"))
-    if msgs_warning:
-        txt_warning = tabulate(msgs_warning, tablefmt="plain")
+    if resp_data["responses"]:
+        print(tabulate(resp_data["responses"], tablefmt="plain"))
+    if resp_data["warnings"]:
+        txt_warning = tabulate(resp_data["warnings"], tablefmt="plain")
         logging.warning("WHOIS errors:\n%s", txt_warning)


### PR DESCRIPTION
Implement main lookup logic into a basic API function, `get_domain_whois()`.

- Factor main logic into callable library function
- Change type of output object from a list to a dict to include encountered errors for the caller
- Increase module documentation
- Update tests to point directly to module

Closes #7.